### PR TITLE
selinux: use kernel linux/socket.h for genheaders and mdp

### DIFF
--- a/scripts/selinux/genheaders/genheaders.c
+++ b/scripts/selinux/genheaders/genheaders.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <errno.h>
 #include <ctype.h>
-#include <sys/socket.h>
 
 struct security_class_mapping {
 	const char *name;

--- a/scripts/selinux/mdp/mdp.c
+++ b/scripts/selinux/mdp/mdp.c
@@ -32,7 +32,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
-#include <sys/socket.h>
 
 static void usage(char *name)
 {

--- a/security/selinux/include/classmap.h
+++ b/security/selinux/include/classmap.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 #include <linux/capability.h>
+#include <linux/socket.h>
 
 #define COMMON_FILE_SOCK_PERMS "ioctl", "read", "write", "create", \
     "getattr", "setattr", "lock", "relabelfrom", "relabelto", "append", "map"


### PR DESCRIPTION
在Ubuntu比较新的版本（比如说21.04）下面编译失败。在Google上找到了此问题的解决方案：
https://review.lineageos.org/c/LineageOS/android_kernel_xiaomi_violet/+/251664/1

但是不确定此补丁是否会导致旧版本的Ubuntu编译失败，如果可以的话，请您确认后再进行Merge，可以吗？